### PR TITLE
Remove redundant code paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,12 +559,12 @@ and only headers (for example):
 
 
 ```julia
-hdrs = readhdrs(io, 2:3, 4)
-readhdrs!(io, hdrs, 2:3, 4) # in-place version of previous line//
+hdrs = readhdrs(io, :, 2:3, 4)
+readhdrs!(io, hdrs, :, 2:3, 4) # in-place version of previous line//
 ```
 
 
-Note that when using `readhdrs` and `readhdrs!` one does not specify a slice range for the first dimension.
+Note that when using `readhdrs` and `readhdrs!` the slice range for the first dimension is always `:`.
 
 
 **Writing:**
@@ -827,18 +827,18 @@ copy!(io, hdrs, io1, hdrs1) # copy values from `hdrs1::Array{UInt8,2}` to `hdrs:
 - [`Base.close`](README.md#Base.close-Tuple{TeaSeis.JSeis})
 - [`Base.copy!`](README.md#Base.copy!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},TeaSeis.JSeis,AbstractArray{UInt8,2}})
 - [`Base.empty!`](README.md#Base.empty!-Tuple{TeaSeis.JSeis})
+- [`Base.get`](README.md#Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},AbstractArray{UInt8,1}}} where T<:Number)
 - [`Base.get`](README.md#Base.get-Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64})
-- [`Base.get`](README.md#Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},Array{UInt8,1}}} where T<:Number)
 - [`Base.in`](README.md#Base.in-Tuple{Union{String, TeaSeis.TraceProperty, TeaSeis.TracePropertyDef},TeaSeis.JSeis})
 - [`Base.ind2sub`](README.md#Base.ind2sub-Tuple{TeaSeis.JSeis,Int64})
 - [`Base.isempty`](README.md#Base.isempty-Tuple{TeaSeis.JSeis})
 - [`Base.length`](README.md#Base.length-Tuple{TeaSeis.JSeis})
 - [`Base.ndims`](README.md#Base.ndims-Tuple{TeaSeis.JSeis})
-- [`Base.read`](README.md#Base.read-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
-- [`Base.read!`](README.md#Base.read!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
-- [`Base.size`](README.md#Base.size-Tuple{TeaSeis.JSeis})
+- [`Base.read`](README.md#Base.read-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
+- [`Base.read!`](README.md#Base.read!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
 - [`Base.size`](README.md#Base.size-Tuple{TeaSeis.JSeis,Int64})
-- [`Base.write`](README.md#Base.write-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
+- [`Base.size`](README.md#Base.size-Tuple{TeaSeis.JSeis})
+- [`Base.write`](README.md#Base.write-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
 - [`Base.write`](README.md#Base.write)
 - [`TeaSeis.allocframe`](README.md#TeaSeis.allocframe-Tuple{TeaSeis.JSeis})
 - [`TeaSeis.allocframehdrs`](README.md#TeaSeis.allocframehdrs-Tuple{TeaSeis.JSeis})
@@ -869,18 +869,18 @@ copy!(io, hdrs, io1, hdrs1) # copy values from `hdrs1::Array{UInt8,2}` to `hdrs:
 - [`TeaSeis.propdefs`](README.md#TeaSeis.propdefs-Tuple{TeaSeis.JSeis})
 - [`TeaSeis.props`](README.md#TeaSeis.props-Tuple{TeaSeis.JSeis,Int64})
 - [`TeaSeis.props`](README.md#TeaSeis.props-Tuple{TeaSeis.JSeis})
-- [`TeaSeis.pstarts`](README.md#TeaSeis.pstarts-Tuple{TeaSeis.JSeis})
 - [`TeaSeis.pstarts`](README.md#TeaSeis.pstarts-Tuple{TeaSeis.JSeis,Int64})
+- [`TeaSeis.pstarts`](README.md#TeaSeis.pstarts-Tuple{TeaSeis.JSeis})
 - [`TeaSeis.readframe`](README.md#TeaSeis.readframe-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N})
 - [`TeaSeis.readframe!`](README.md#TeaSeis.readframe!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},AbstractArray{UInt8,2},Vararg{Int64,N} where N})
 - [`TeaSeis.readframehdrs`](README.md#TeaSeis.readframehdrs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N})
 - [`TeaSeis.readframehdrs!`](README.md#TeaSeis.readframehdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},Vararg{Int64,N} where N})
 - [`TeaSeis.readframetrcs`](README.md#TeaSeis.readframetrcs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N})
 - [`TeaSeis.readframetrcs!`](README.md#TeaSeis.readframetrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},Vararg{Int64,N} where N})
-- [`TeaSeis.readhdrs`](README.md#TeaSeis.readhdrs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
-- [`TeaSeis.readhdrs!`](README.md#TeaSeis.readhdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
-- [`TeaSeis.readtrcs`](README.md#TeaSeis.readtrcs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
-- [`TeaSeis.readtrcs!`](README.md#TeaSeis.readtrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N})
+- [`TeaSeis.readhdrs`](README.md#TeaSeis.readhdrs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
+- [`TeaSeis.readhdrs!`](README.md#TeaSeis.readhdrs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
+- [`TeaSeis.readtrcs`](README.md#TeaSeis.readtrcs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
+- [`TeaSeis.readtrcs!`](README.md#TeaSeis.readtrcs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N)
 - [`TeaSeis.regularize!`](README.md#TeaSeis.regularize!-Tuple{TeaSeis.JSeis,Array{Float32,2},Array{UInt8,2}})
 - [`TeaSeis.set!`](README.md#TeaSeis.set!-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64,T}} where T<:Number)
 - [`TeaSeis.units`](README.md#TeaSeis.units-Tuple{TeaSeis.JSeis,Int64})
@@ -900,7 +900,7 @@ allocframe(io)
 Allocate memory for one frame of JavaSeis dataset.  Returns `(Array{Float32,2},Array{UInt8,2})`. For example, `trcs, hdrs = allocframe(jsopen("data.js"))`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1212-L1217' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1209-L1214' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.allocframehdrs-Tuple{TeaSeis.JSeis}' href='#TeaSeis.allocframehdrs-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.allocframehdrs`** &mdash; *Method*.
@@ -912,7 +912,7 @@ allocframehdrs(io)
 Allocate memory for headers for one frame of JavaSeis dataset.  Returns `Array{UInt8,2}`. For example, `hdrs = allocframehdrs(jsopen("data.js"))`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1219-L1224' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1216-L1221' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.allocframetrcs-Tuple{TeaSeis.JSeis}' href='#TeaSeis.allocframetrcs-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.allocframetrcs`** &mdash; *Method*.
@@ -924,7 +924,7 @@ allocframetrcs(io)
 Allocate memory for traces for one frame of JavaSeis dataset.  Returns `Array{Float32,2}`. For example, `trcs = allocframetrcs(jsopen("data.js"))`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1226-L1231' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1223-L1228' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.dataproperty-Tuple{TeaSeis.JSeis,String}' href='#TeaSeis.dataproperty-Tuple{TeaSeis.JSeis,String}'>#</a>
 **`TeaSeis.dataproperty`** &mdash; *Method*.
@@ -938,7 +938,7 @@ dataproperty(io, label)
 Get a data property (data properties are per file, rather than per trace) from `io::JSeis` with label `label::String`.  For example, `dataproperty(jsopen("data.js"), "FREQUENCY")`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1182-L1187' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1179-L1184' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.domains-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.domains-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.domains`** &mdash; *Method*.
@@ -952,7 +952,7 @@ domains(io, i)
 Returns the domain of the ith dimension of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2449-L2454' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2220-L2225' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.domains-Tuple{TeaSeis.JSeis}' href='#TeaSeis.domains-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.domains`** &mdash; *Method*.
@@ -966,7 +966,7 @@ domains(io)
 Returns the domains of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2442-L2447' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2213-L2218' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.fold-Tuple{TeaSeis.JSeis,Array{UInt8,2}}' href='#TeaSeis.fold-Tuple{TeaSeis.JSeis,Array{UInt8,2}}'>#</a>
 **`TeaSeis.fold`** &mdash; *Method*.
@@ -980,7 +980,7 @@ fold(io, hdrs)
 Compute the fold of a frame where io is JSeis corresponding to the dataset, and hdrs are the headers for the frame. For example: `io=jsopen("file.js"); fold(io, readframehdrs(io,1))`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L926-L931' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L922-L927' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.fold-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}' href='#TeaSeis.fold-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.fold`** &mdash; *Method*.
@@ -994,7 +994,7 @@ fold(io, idx...)
 Compute the fold of a frame where idx is the frame/volume/hypercube indices.  For example, `fold(jsopen("file.js"),1)` for a 3D dataset, `fold(jsopen("file.js",1,2))` for a 4D dataset, and `fold(jsopen("file.js"),1,2,3)` for a 5D dataset.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L937-L942' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L933-L938' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.geometry-Tuple{TeaSeis.JSeis}' href='#TeaSeis.geometry-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.geometry`** &mdash; *Method*.
@@ -1008,7 +1008,7 @@ geometry(io)
 If `io::JSeis` contains a geometry definition, then return a geometry of type `Geometry`.  Otherwise, return `nothing`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2541-L2546' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2312-L2317' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.hasdataproperty-Tuple{Any,Any}' href='#TeaSeis.hasdataproperty-Tuple{Any,Any}'>#</a>
 **`TeaSeis.hasdataproperty`** &mdash; *Method*.
@@ -1022,7 +1022,7 @@ hasdataproperty(io, label)
 return true if `io::JSeis` contains the data property corresponding to `label`.  Otherwise, return false.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1197-L1201' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1194-L1198' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.jscreate-Tuple{String}' href='#TeaSeis.jscreate-Tuple{String}'>#</a>
 **`TeaSeis.jscreate`** &mdash; *Method*.
@@ -1036,7 +1036,7 @@ jscreate(filename)
 Create a JavaSeis dataset without opening it.  This method has the same optional arguments as `jsopen`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L363-L367' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L363-L367' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.jsopen-Tuple{String,String}' href='#TeaSeis.jsopen-Tuple{String,String}'>#</a>
 **`TeaSeis.jsopen`** &mdash; *Method*.
@@ -1078,7 +1078,7 @@ If `"w"` is used for the value of `mode`, then the `axis_lengths` named paramete
   * `dataproperties_rm::Array{DataProperty}` When `similarto` is specified, use this to remove dataset properties to those already existing in the `similarto` file.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L32-L66' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L32-L66' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.jsopen-Tuple{String}' href='#TeaSeis.jsopen-Tuple{String}'>#</a>
 **`TeaSeis.jsopen`** &mdash; *Method*.
@@ -1092,7 +1092,7 @@ jsopen(filename)
 Equivalent to `jsopen(filename, "r")`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L356-L360' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L356-L360' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.labels-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.labels-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.labels`** &mdash; *Method*.
@@ -1106,7 +1106,7 @@ labels(io, i)
 Returns the string label of the ith framework axis of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2393-L2398' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2164-L2169' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.labels-Tuple{TeaSeis.JSeis}' href='#TeaSeis.labels-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.labels`** &mdash; *Method*.
@@ -1120,7 +1120,7 @@ labels(io)
 Returns the string labels corresponding to the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2386-L2391' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2157-L2162' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.leftjustify!-Tuple{TeaSeis.JSeis,Array{Float32,2},Array{UInt8,2}}' href='#TeaSeis.leftjustify!-Tuple{TeaSeis.JSeis,Array{Float32,2},Array{UInt8,2}}'>#</a>
 **`TeaSeis.leftjustify!`** &mdash; *Method*.
@@ -1134,7 +1134,7 @@ leftjustify(io, trcs, hdrs)
 Left justify all live (non-dead) traces in a frame, moving them to the beginning of `trcs` and `hdrs`.  See also `regularize!`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2258-L2263' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2029-L2034' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lincs-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.lincs-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.lincs`** &mdash; *Method*.
@@ -1148,7 +1148,7 @@ lincs(io,i)
 Returns the logical increment of the framework axes for dimension `i` of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2505-L2510' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2276-L2281' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lincs-Tuple{TeaSeis.JSeis}' href='#TeaSeis.lincs-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.lincs`** &mdash; *Method*.
@@ -1162,7 +1162,7 @@ lincs(io)
 Returns the logical increments of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2498-L2503' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2269-L2274' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lrange-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.lrange-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.lrange`** &mdash; *Method*.
@@ -1176,7 +1176,7 @@ lrange(io, i)
 Returns the logical range of the framework axes for dimension `i` of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2519-L2524' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2290-L2295' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lrange-Tuple{TeaSeis.JSeis}' href='#TeaSeis.lrange-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.lrange`** &mdash; *Method*.
@@ -1190,7 +1190,7 @@ lrange(io)
 Returns the logical ranges of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2512-L2517' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2283-L2288' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lstarts-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.lstarts-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.lstarts`** &mdash; *Method*.
@@ -1204,7 +1204,7 @@ lstarts(io,i)
 Returns the logical start of the framework axes for dimension `i` of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2491-L2496' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2262-L2267' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.lstarts-Tuple{TeaSeis.JSeis}' href='#TeaSeis.lstarts-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.lstarts`** &mdash; *Method*.
@@ -1218,7 +1218,7 @@ lstarts(io)
 Returns the logical start of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2484-L2489' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2255-L2260' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.pincs-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.pincs-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.pincs`** &mdash; *Method*.
@@ -1232,7 +1232,7 @@ pincs(io, i)
 Returns the physical increments of the framework axes for dimension `i` of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2477-L2482' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2248-L2253' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.pincs-Tuple{TeaSeis.JSeis}' href='#TeaSeis.pincs-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.pincs`** &mdash; *Method*.
@@ -1246,7 +1246,7 @@ pincs(io)
 Returns the physical increments of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2470-L2475' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2241-L2246' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.prop-Tuple{TeaSeis.JSeis,String}' href='#TeaSeis.prop-Tuple{TeaSeis.JSeis,String}'>#</a>
 **`TeaSeis.prop`** &mdash; *Method*.
@@ -1266,7 +1266,7 @@ p = prop(io, stockprop[:REC_X])  # using a `TracePropertyDef`
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1107-L1118' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1104-L1115' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.propdefs-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.propdefs-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.propdefs`** &mdash; *Method*.
@@ -1280,7 +1280,7 @@ propdefs(io, i)
 Returns the property definition of the ith framework axis of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2407-L2412' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2178-L2183' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.propdefs-Tuple{TeaSeis.JSeis}' href='#TeaSeis.propdefs-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.propdefs`** &mdash; *Method*.
@@ -1294,7 +1294,7 @@ propdefs(io)
 Returns the property definitions of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2400-L2405' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2171-L2176' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.props-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.props-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.props`** &mdash; *Method*.
@@ -1308,7 +1308,7 @@ props(io, i)
 Returns the trace property of the ith framework axis of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2421-L2426' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2192-L2197' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.props-Tuple{TeaSeis.JSeis}' href='#TeaSeis.props-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.props`** &mdash; *Method*.
@@ -1322,7 +1322,7 @@ props(io)
 Returns the trace properties of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2414-L2419' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2185-L2190' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.pstarts-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.pstarts-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.pstarts`** &mdash; *Method*.
@@ -1336,7 +1336,7 @@ pstarts(io, i)
 Returns the physical start of the ith dimension of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2463-L2468' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2234-L2239' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.pstarts-Tuple{TeaSeis.JSeis}' href='#TeaSeis.pstarts-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.pstarts`** &mdash; *Method*.
@@ -1350,7 +1350,7 @@ pstarts(io)
 Returns the physical start of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2456-L2461' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2227-L2232' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframe!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},AbstractArray{UInt8,2},Vararg{Int64,N} where N}' href='#TeaSeis.readframe!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},AbstractArray{UInt8,2},Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframe!`** &mdash; *Method*.
@@ -1391,7 +1391,7 @@ readframe!(io, trcs, hdrs, frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1302-L1334' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1300-L1332' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframe-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}' href='#TeaSeis.readframe-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframe`** &mdash; *Method*.
@@ -1426,7 +1426,7 @@ trcs, hdrs = readframe(jsopen("data_5D.js"), frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1337-L1363' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1336-L1362' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframehdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},Vararg{Int64,N} where N}' href='#TeaSeis.readframehdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframehdrs!`** &mdash; *Method*.
@@ -1467,7 +1467,7 @@ readframehdrs!(io, hdrs, frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1430-L1462' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1432-L1464' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframehdrs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}' href='#TeaSeis.readframehdrs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframehdrs`** &mdash; *Method*.
@@ -1500,7 +1500,7 @@ hdrs = readframehdrs(jsopen("data_5D.js"), frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1465-L1491' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1468-L1494' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframetrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},Vararg{Int64,N} where N}' href='#TeaSeis.readframetrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframetrcs!`** &mdash; *Method*.
@@ -1541,7 +1541,7 @@ readframetrcs!(io, trcs, frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1366-L1398' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1366-L1398' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.readframetrcs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}' href='#TeaSeis.readframetrcs-Tuple{TeaSeis.JSeis,Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.readframetrcs`** &mdash; *Method*.
@@ -1576,15 +1576,15 @@ trcs = readframetrcs(jsopen("data_5D.js"), frm_idx, vol_idx, hyp_idx)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1401-L1427' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1402-L1428' class='documenter-source'>source</a><br>
 
-<a id='TeaSeis.readhdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#TeaSeis.readhdrs!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='TeaSeis.readhdrs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#TeaSeis.readhdrs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`TeaSeis.readhdrs!`** &mdash; *Method*.
 
 
 
 ```
-readhdrs!(io, hdrs, trace_range, range...)
+readhdrs!(io, hdrs, smp_range, trace_range, range...)
 ```
 
 In-place read of a subset of data (headers only) from a JavaSeis file. If performance is important, then consider using `readframehdrs!` instead.  Examples:
@@ -1592,28 +1592,28 @@ In-place read of a subset of data (headers only) from a JavaSeis file. If perfor
 **3D:**
 
 ```julia
-readhdrs!(jsopen("data_3D.js"), hdrs, :, :)
-readhdrs!(jsopen("data_3D.js"), hdrs, 1:2:end, 1:5)
+readhdrs!(jsopen("data_3D.js"), hdrs, :, :, :)
+readhdrs!(jsopen("data_3D.js"), hdrs, :, 1:2:end, 1:5)
 ```
 
 **4D:**
 
 ```julia
-readhdrs!(jsopen("data_4D.js"), hdrs, :, :, :)
-readhdrs!(jsopen("data_4D.js"), hdrs, :, 2, 2:2:10)
+readhdrs!(jsopen("data_4D.js"), hdrs, :, :, :, :)
+readhdrs!(jsopen("data_4D.js"), hdrs, :, :, 2, 2:2:10)
 ```
 
 **5D:**
 
 ```julia
-readhdrs!(jsopen("data_5D.js"), hdrs, :, :, :, :)
-readhdrs!(jsopen("data_5D.js"), hdrs, :, 2, 2:2:10, 1:10)
+readhdrs!(jsopen("data_5D.js"), hdrs, :, :, :, :, :)
+readhdrs!(jsopen("data_5D.js"), hdrs, :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1792-L1818' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1645-L1671' class='documenter-source'>source</a><br>
 
-<a id='TeaSeis.readhdrs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#TeaSeis.readhdrs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='TeaSeis.readhdrs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#TeaSeis.readhdrs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`TeaSeis.readhdrs`** &mdash; *Method*.
 
 
@@ -1646,9 +1646,9 @@ hdrs = readhdrs(jsopen("data_5D.js"), :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1825-L1850' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1679-L1704' class='documenter-source'>source</a><br>
 
-<a id='TeaSeis.readtrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#TeaSeis.readtrcs!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='TeaSeis.readtrcs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#TeaSeis.readtrcs!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`TeaSeis.readtrcs!`** &mdash; *Method*.
 
 
@@ -1681,9 +1681,9 @@ readtrcs!(jsopen("data_5D.js"), trcs, :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1726-L1751' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1579-L1604' class='documenter-source'>source</a><br>
 
-<a id='TeaSeis.readtrcs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#TeaSeis.readtrcs-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='TeaSeis.readtrcs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#TeaSeis.readtrcs-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`TeaSeis.readtrcs`** &mdash; *Method*.
 
 
@@ -1716,7 +1716,7 @@ trcs = readtrcs(jsopen("data_5D.js"), :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1758-L1784' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1611-L1637' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.regularize!-Tuple{TeaSeis.JSeis,Array{Float32,2},Array{UInt8,2}}' href='#TeaSeis.regularize!-Tuple{TeaSeis.JSeis,Array{Float32,2},Array{UInt8,2}}'>#</a>
 **`TeaSeis.regularize!`** &mdash; *Method*.
@@ -1730,7 +1730,7 @@ regularize!(io, trcs, hdrs)
 Regularize the traces in a frame, moving them from their left-justified state, to one that reflects their trace location within a frame according to their trace framework definition.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2322-L2327' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2093-L2098' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.set!-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64,T}} where T<:Number' href='#TeaSeis.set!-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64,T}} where T<:Number'>#</a>
 **`TeaSeis.set!`** &mdash; *Method*.
@@ -1744,7 +1744,7 @@ set!(prop, hdrs, i, value)
 Set the value of the trace property `prop::TraceProperty` stored in the header of the ith column of `hdrs::Array{UInt8,2}` to `value::T`.  For example, `io=jsopen("test.js"); hdrs=readframehdrs(io,1); set!(prop(io,"REC_X"), 1, 10.0)`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1081-L1087' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1078-L1084' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.units-Tuple{TeaSeis.JSeis,Int64}' href='#TeaSeis.units-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`TeaSeis.units`** &mdash; *Method*.
@@ -1758,7 +1758,7 @@ units(io, i)
 Returns the unit of measure of the ith dimension of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2435-L2440' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2206-L2211' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.units-Tuple{TeaSeis.JSeis}' href='#TeaSeis.units-Tuple{TeaSeis.JSeis}'>#</a>
 **`TeaSeis.units`** &mdash; *Method*.
@@ -1772,7 +1772,7 @@ units(io)
 Returns the unit of measure of the framework axes of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2428-L2433' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2199-L2204' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.writeframe-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},AbstractArray{UInt8,2},Int64}' href='#TeaSeis.writeframe-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},AbstractArray{UInt8,2},Int64}'>#</a>
 **`TeaSeis.writeframe`** &mdash; *Method*.
@@ -1786,7 +1786,7 @@ writeframe(io, trcs, hdrs)
 Write a frame of data to the JavaSeis dataset corresponding to `io::JSeis`.  `trcs` and `hdrs` are 2-dimensional arrays. The location of the dataset written to is determined by the values of the framework headers stored in `hdrs`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1969-L1974' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1824-L1829' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.writeframe-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},Vararg{Int64,N} where N}' href='#TeaSeis.writeframe-Tuple{TeaSeis.JSeis,AbstractArray{Float32,2},Vararg{Int64,N} where N}'>#</a>
 **`TeaSeis.writeframe`** &mdash; *Method*.
@@ -1818,7 +1818,7 @@ writeframe(jsopen("data_5D.js"), trcs, 1, 2, 3) # write to frame 1, volume 2, hy
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1981-L2004' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1836-L1859' class='documenter-source'>source</a><br>
 
 <a id='TeaSeis.Geometry-Tuple{}' href='#TeaSeis.Geometry-Tuple{}'>#</a>
 **`TeaSeis.Geometry`** &mdash; *Method*.
@@ -1843,7 +1843,7 @@ where `g::Geometry`.  The named arguments are:
   * `wn=2` maximum depth index
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/geometry.jl#L22-L37' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/geometry.jl#L22-L37' class='documenter-source'>source</a><br>
 
 <a id='Base.Filesystem.cp-Tuple{TeaSeis.JSeis,AbstractString}' href='#Base.Filesystem.cp-Tuple{TeaSeis.JSeis,AbstractString}'>#</a>
 **`Base.Filesystem.cp`** &mdash; *Method*.
@@ -1857,7 +1857,7 @@ cp(src, dst, [secondaries=nothing])
 Copy a file from `src` (of type `JSeis`) to `dst` of type `String`.  For example, `cp(jsopen("copyfrom.js"), "copyto.js")`. Use the optional named argument `secondaries` to change the JavaSeis secondary location.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L426-L431' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L426-L431' class='documenter-source'>source</a><br>
 
 <a id='Base.Filesystem.mv-Tuple{TeaSeis.JSeis,AbstractString}' href='#Base.Filesystem.mv-Tuple{TeaSeis.JSeis,AbstractString}'>#</a>
 **`Base.Filesystem.mv`** &mdash; *Method*.
@@ -1871,7 +1871,7 @@ mv(src, dst, [secondaries=nothing])
 Move a file from `src` (of type `JSeis`) to `dst` of type `String`.  For example, `cp(jsopen("movefrom.js"), "moveto.js")`. Use the optional named argument `secondaries` to change the JavaSeis secondary location.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L444-L449' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L444-L449' class='documenter-source'>source</a><br>
 
 <a id='Base.Filesystem.rm-Tuple{TeaSeis.JSeis}' href='#Base.Filesystem.rm-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.Filesystem.rm`** &mdash; *Method*.
@@ -1885,7 +1885,7 @@ rm(io)
 Remove a JavaSeis dataset from disk.  For example: `rm(jsopen("deleteme.js"))`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L379-L383' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L379-L383' class='documenter-source'>source</a><br>
 
 <a id='Base.close-Tuple{TeaSeis.JSeis}' href='#Base.close-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.close`** &mdash; *Method*.
@@ -1899,7 +1899,7 @@ close(io)
 Close an open JavaSeis dataset where `io` is of type `JSeis` created using, for example, `jsopen`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L370-L374' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L370-L374' class='documenter-source'>source</a><br>
 
 <a id='Base.copy!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},TeaSeis.JSeis,AbstractArray{UInt8,2}}' href='#Base.copy!-Tuple{TeaSeis.JSeis,AbstractArray{UInt8,2},TeaSeis.JSeis,AbstractArray{UInt8,2}}'>#</a>
 **`Base.copy!`** &mdash; *Method*.
@@ -1921,7 +1921,7 @@ copy!(ioout, hdrsout, ioin, hdrsin)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1129-L1142' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1126-L1139' class='documenter-source'>source</a><br>
 
 <a id='Base.empty!-Tuple{TeaSeis.JSeis}' href='#Base.empty!-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.empty!`** &mdash; *Method*.
@@ -1935,7 +1935,7 @@ empty!(io)
 Empty a JavaSeis dataset from disk, retaining the meta-information.  For example: `empty!(jsopen("emptyme.js"))`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L391-L395' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L391-L395' class='documenter-source'>source</a><br>
 
 <a id='Base.get-Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64}' href='#Base.get-Tuple{TeaSeis.TraceProperty,AbstractArray{UInt8,2},Int64}'>#</a>
 **`Base.get`** &mdash; *Method*.
@@ -1949,9 +1949,9 @@ get(prop, hdrs, i)
 Get the value of the trace property `prop::TraceProperty` stored in the header of the ith column of `hdrs::Array{UInt8,2}`.  For example, `io=jsopen("data.js"); get(prop(io, "REC_X"), readframehdrs(io,1), 1)`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1073-L1078' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1070-L1075' class='documenter-source'>source</a><br>
 
-<a id='Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},Array{UInt8,1}}} where T<:Number' href='#Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},Array{UInt8,1}}} where T<:Number'>#</a>
+<a id='Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},AbstractArray{UInt8,1}}} where T<:Number' href='#Base.get-Union{Tuple{T}, Tuple{TeaSeis.TraceProperty{T},AbstractArray{UInt8,1}}} where T<:Number'>#</a>
 **`Base.get`** &mdash; *Method*.
 
 
@@ -1963,7 +1963,7 @@ get(prop, hdr)
 Get the value of the trace property `prop::TraceProperty` stored in the header `hdr::Array{UInt8,1}`.  For example, `io=jsopen("data.js"); get(prop(io, "REC_X"), readframehdrs(io,1)[:,1])`
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1052-L1057' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1049-L1054' class='documenter-source'>source</a><br>
 
 <a id='Base.in-Tuple{Union{String, TeaSeis.TraceProperty, TeaSeis.TracePropertyDef},TeaSeis.JSeis}' href='#Base.in-Tuple{Union{String, TeaSeis.TraceProperty, TeaSeis.TracePropertyDef},TeaSeis.JSeis}'>#</a>
 **`Base.in`** &mdash; *Method*.
@@ -1977,7 +1977,7 @@ in(trace_property, io)
 Returns true if `trace_property` is in the header catalog of `io::JSeis`, and where `trace_property` is one of `String`, `TracePropertyDef` or `TraceProperty`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2533-L2538' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2304-L2309' class='documenter-source'>source</a><br>
 
 <a id='Base.ind2sub-Tuple{TeaSeis.JSeis,Int64}' href='#Base.ind2sub-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`Base.ind2sub`** &mdash; *Method*.
@@ -1997,7 +1997,7 @@ end
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2240-L2252' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2011-L2023' class='documenter-source'>source</a><br>
 
 <a id='Base.isempty-Tuple{TeaSeis.JSeis}' href='#Base.isempty-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.isempty`** &mdash; *Method*.
@@ -2011,7 +2011,7 @@ isempty(io)
 Returns true if the dataset correpsonding to `io` is empty (contains no data), and false otherwise.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2526-L2531' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2297-L2302' class='documenter-source'>source</a><br>
 
 <a id='Base.length-Tuple{TeaSeis.JSeis}' href='#Base.length-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.length`** &mdash; *Method*.
@@ -2025,7 +2025,7 @@ length(io)
 Returns the number of frames in a JavaSeis dataset corresponding to `io::JSeis`. This is equivalent to `prod(size(io)[3:end])`, and is useful for iterating over all frames in a JavaSeis dataset.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2378-L2384' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2149-L2155' class='documenter-source'>source</a><br>
 
 <a id='Base.ndims-Tuple{TeaSeis.JSeis}' href='#Base.ndims-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.ndims`** &mdash; *Method*.
@@ -2039,9 +2039,9 @@ ndims(io)
 Returns the numbers of dimensions of the JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2360-L2364' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2131-L2135' class='documenter-source'>source</a><br>
 
-<a id='Base.read!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#Base.read!-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='Base.read!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#Base.read!-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,AbstractArray{UInt8,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`Base.read!`** &mdash; *Method*.
 
 
@@ -2074,9 +2074,9 @@ read!(jsopen("data_5D.js"), trcs, hdrs, :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1858-L1883' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1713-L1738' class='documenter-source'>source</a><br>
 
-<a id='Base.read-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#Base.read-Tuple{TeaSeis.JSeis,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='Base.read-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#Base.read-Union{Tuple{N}, Tuple{TeaSeis.JSeis,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`Base.read`** &mdash; *Method*.
 
 
@@ -2109,7 +2109,7 @@ trcs, hdrs = read(jsopen("data_5D.js"), :, :, 2, 2:2:10, 1:10)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L1891-L1916' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1746-L1771' class='documenter-source'>source</a><br>
 
 <a id='Base.size-Tuple{TeaSeis.JSeis,Int64}' href='#Base.size-Tuple{TeaSeis.JSeis,Int64}'>#</a>
 **`Base.size`** &mdash; *Method*.
@@ -2123,7 +2123,7 @@ size(io, i)
 Returns the lenth of dimension i of a JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2372-L2376' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2143-L2147' class='documenter-source'>source</a><br>
 
 <a id='Base.size-Tuple{TeaSeis.JSeis}' href='#Base.size-Tuple{TeaSeis.JSeis}'>#</a>
 **`Base.size`** &mdash; *Method*.
@@ -2137,7 +2137,7 @@ size(io)
 Returns the lenths of all dimensions (as a tuple of integers) of a JavaSeis dataset corresponding to `io::JSeis`.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2366-L2370' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L2137-L2141' class='documenter-source'>source</a><br>
 
 <a id='Base.write' href='#Base.write'>#</a>
 **`Base.write`** &mdash; *Function*.
@@ -2151,9 +2151,9 @@ write(io, trcs, hdrs[, smprng=:])
 Write `trcs` and `hdrs` to the file corresponding to `io::JSeis`.  Optionally, you can limit which samples are written. The locations that are written to are determined by the values corresponding to the framework headers `hdrs`.  Note that the dimension of the arrays `trcs` and `hdrs` must match the number of dimensions in the framework.
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2018-L2024' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1874-L1880' class='documenter-source'>source</a><br>
 
-<a id='Base.write-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}' href='#Base.write-Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Union{Colon, Int64, Range{Int64}},Union{Colon, Int64, Range{Int64}},Vararg{Union{Colon, Int64, Range{Int64}},N} where N}'>#</a>
+<a id='Base.write-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N' href='#Base.write-Union{Tuple{N}, Tuple{TeaSeis.JSeis,AbstractArray{Float32,N} where N,Vararg{Union{Colon, Int64, Range{Int64}},N}}} where N'>#</a>
 **`Base.write`** &mdash; *Method*.
 
 
@@ -2183,5 +2183,5 @@ write(io, trcs, :, :, :, :, :)
 ```
 
 
-<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/08653b78bece7eaa926adf32c6b9502631a7d250/src/teaseisio.jl#L2061-L2084' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/ChevronETC/TeaSeis.jl/blob/37f5f5ec271ab1e2ad027e8f909f58fc7d870980/src/teaseisio.jl#L1912-L1935' class='documenter-source'>source</a><br>
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -326,10 +326,10 @@ readtrcs!(io, trcs, 1:10, 2:3, 4) # in-place version of previous line
 ```
 and only headers (for example):
 ```julia
-hdrs = readhdrs(io, 2:3, 4)
-readhdrs!(io, hdrs, 2:3, 4) # in-place version of previous line//
+hdrs = readhdrs(io, :, 2:3, 4)
+readhdrs!(io, hdrs, :, 2:3, 4) # in-place version of previous line//
 ```
-Note that when using `readhdrs` and `readhdrs!` one does not specify a slice range for the first dimension.
+Note that when using `readhdrs` and `readhdrs!` the slice range for the first dimension is always `:`.
 
 **Writing:**
 ```julia

--- a/test/test_teaseisio.jl
+++ b/test/test_teaseisio.jl
@@ -65,7 +65,7 @@ mkdir(rundir)
     end
     close(io)
     io = jsopen(joinpath(rundir, "data.js"))
-    hdrs = view(readhdrs(io, :, 511), :, :, 1)
+    hdrs = view(readhdrs(io, :, :, 511), :, :, 1)
     for j = 1:6
         @test get(prop(io, stockprop[:TRACE]), hdrs, j) == 999+j
     end


### PR DESCRIPTION
I thought that the extra code paths were needed to help with performance, but this seems to perform just as well.