### PR TITLE
Handle corrupt status files

### DIFF
--- a/src/teaseisio.jl
+++ b/src/teaseisio.jl
@@ -608,6 +608,10 @@ function get_status(io::IOStream)
     for ln in eachline(io)
         if ln[1] != '#'
             x = split(ln, '=')
+            if length(x) < 2
+                warn("Corrupt status information. Status information, i.e. \"has traces\", may be incorrect.")
+                return false
+            end
             if chomp(x[2]) == "true"
                 return true
             end

--- a/test/test_teaseisio.jl
+++ b/test/test_teaseisio.jl
@@ -160,7 +160,11 @@ mkdir(rundir)
         end
     end
     close(io)
-    @test_warn "Corrupt" jsopen(joinpath(rundir, "data.js"))
+    if VERSION >= v"0.6.0"
+        @test_warn "Corrupt" jsopen(joinpath(rundir, "data.js"))
+    else
+        jsopen(joinpath(rundir, "data.js"))
+    end
     rm(jsopen(joinpath(rundir,"data.js")))
 
     @testset "lstrt=$(lstrt),lincrs=$(lincrs),sz=$(sz),second=$(second),T=$(T)" for lstrt in ([1,1,1,1,1], [10,20,30,40,50]), lincrs in ([1,1,1,1,1],[1,2,3,4,5]), sz in ([5,6,7], [5,6,7,8], [5,6,7,8,9]), second in (["."],["$(rundir)/second"]), T in (Float32, Int16)

--- a/test/test_teaseisio.jl
+++ b/test/test_teaseisio.jl
@@ -146,6 +146,23 @@ mkdir(rundir)
     @test fold(io, 3) == 0
     rm(jsopen(joinpath(rundir,"data.js")))
 
+    # don't fail on a corrupt status file
+    io = jsopen(joinpath(rundir, "data.js"), "w", axis_lengths=[10,11,12])
+    io = open(joinpath(rundir, "data.js", "Status.properties"))
+    lines = readlines(io)
+    close(io)
+    io = open(joinpath(rundir,"data.js", "Status.properties"),"w")
+    for line in lines
+        if !startswith(line,"#")
+            write(io,split(line,'=')[1]*"\n")
+        else
+            write(io,line*"\n")
+        end
+    end
+    close(io)
+    @test_warn "Corrupt" jsopen(joinpath(rundir, "data.js"))
+    rm(jsopen(joinpath(rundir,"data.js")))
+
     @testset "lstrt=$(lstrt),lincrs=$(lincrs),sz=$(sz),second=$(second),T=$(T)" for lstrt in ([1,1,1,1,1], [10,20,30,40,50]), lincrs in ([1,1,1,1,1],[1,2,3,4,5]), sz in ([5,6,7], [5,6,7,8], [5,6,7,8,9]), second in (["."],["$(rundir)/second"]), T in (Float32, Int16)
         write(STDOUT, "lstrt=$(lstrt),lincrs=$(lincrs),sz=$(sz),second=$(second),T=$(T)\n")
         labls = ["SAMPLE", "TRACE", "FRAME", "VOLUME", "HYPRCUBE"]

--- a/test/test_teaseisio.jl
+++ b/test/test_teaseisio.jl
@@ -1,5 +1,14 @@
 using TeaSeis, Base.Test
 
+# macro for compatability with julia 0.5
+macro mytest_warn(msg, expr)
+    if VERSION >= v"0.6.0"
+        return :(@test_warn $msg $expr)
+    else
+        return :(nothing)
+    end
+end
+
 ENV["JAVASEIS_DATA_HOME"] = ""
 ENV["PROMAX_DATA_HOME"] = ""
 
@@ -160,11 +169,7 @@ mkdir(rundir)
         end
     end
     close(io)
-    if VERSION >= v"0.6.0"
-        @test_warn "Corrupt" jsopen(joinpath(rundir, "data.js"))
-    else
-        jsopen(joinpath(rundir, "data.js"))
-    end
+    @mytest_warn "Corrupt" jsopen(joinpath(rundir,"data.js")) # see top of file for @mytest_warn macro (for compatability with julia 0.5)
     rm(jsopen(joinpath(rundir,"data.js")))
 
     @testset "lstrt=$(lstrt),lincrs=$(lincrs),sz=$(sz),second=$(second),T=$(T)" for lstrt in ([1,1,1,1,1], [10,20,30,40,50]), lincrs in ([1,1,1,1,1],[1,2,3,4,5]), sz in ([5,6,7], [5,6,7,8], [5,6,7,8,9]), second in (["."],["$(rundir)/second"]), T in (Float32, Int16)


### PR DESCRIPTION
Do not error if the `Status.properties` file is corrupt.  Instead, we display a warning that the status information may be incorrect, keep calm, and carry-on.